### PR TITLE
Fix db persistency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security:$springBootVersion")
     implementation("org.springframework.boot:spring-boot-starter-validation:$springBootVersion")
 
-    implementation("org.flywaydb:flyway-core:10.14.0")
+    implementation("org.flywaydb:flyway-core:10.15.0")
     implementation("jakarta.validation:jakarta.validation-api:3.1.0")
     implementation("org.antlr:antlr4-runtime:4.13.1")
     implementation("com.google.guava:guava:33.2.1-jre")

--- a/src/main/java/uk/ac/warwick/dcs/sherlock/launch/SherlockServer.kt
+++ b/src/main/java/uk/ac/warwick/dcs/sherlock/launch/SherlockServer.kt
@@ -2,15 +2,17 @@ package uk.ac.warwick.dcs.sherlock.launch
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.jdbc.DataSourceBuilder
 import org.springframework.boot.web.servlet.ServletComponentScan
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Primary
-import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import uk.ac.warwick.dcs.sherlock.api.util.Side
@@ -18,10 +20,12 @@ import uk.ac.warwick.dcs.sherlock.engine.SherlockEngine
 import javax.sql.DataSource
 import kotlin.system.exitProcess
 
+
 @SpringBootApplication
 @ComponentScan("uk.ac.warwick.dcs.sherlock.module.web")
 @ServletComponentScan("uk.ac.warwick.dcs.sherlock.module.web")
 @EnableJpaRepositories("uk.ac.warwick.dcs.sherlock.module.web")
+@EnableConfigurationProperties(DataSourceProperties::class)
 @EntityScan("uk.ac.warwick.dcs.sherlock.module.web")
 class SherlockServer : SpringBootServletInitializer() {
     @EventListener(ApplicationReadyEvent::class)
@@ -42,15 +46,9 @@ class SherlockServer : SpringBootServletInitializer() {
 
     @Bean
     @Primary
-    @Profile("server")
+    @ConfigurationProperties("spring.datasource")
     fun dataSource(): DataSource {
-        return DataSourceBuilder
-            .create()
-            .username("sa")
-            .password("")
-            .url("jdbc:h2:file:" + SherlockEngine.configuration.dataPath + "/Sherlock-Web")
-            .driverClassName("org.h2.Driver")
-            .build()
+        return DataSourceBuilder.create().build()
     }
 
     companion object {

--- a/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/Account.kt
+++ b/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/Account.kt
@@ -27,15 +27,15 @@ open class Account(
     var id: Long = 0
 
     @JvmField
-    @OneToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], mappedBy = "account")
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "account", cascade = [CascadeType.REMOVE])
     var roles: MutableSet<Role> = mutableSetOf()
 
     @JvmField
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "account", cascade = [CascadeType.ALL])
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "account", cascade = [CascadeType.REMOVE])
     var workspaces: MutableSet<Workspace> = mutableSetOf()
 
     @JvmField
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "account", cascade = [CascadeType.ALL])
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "account", cascade = [CascadeType.REMOVE])
     var templates: MutableSet<Template> = mutableSetOf()
 
     override operator fun equals(other: Any?): Boolean {

--- a/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/TDetector.kt
+++ b/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/TDetector.kt
@@ -25,7 +25,7 @@ open class TDetector(
     var id: Long = 0
 
     @JvmField
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "tDetector", cascade = [CascadeType.ALL])
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "tDetector", cascade = [CascadeType.REMOVE])
     var parameters: MutableSet<TParameter> = mutableSetOf()
 
     val detectorParameters: Set<TParameter>

--- a/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/Template.kt
+++ b/src/main/java/uk/ac/warwick/dcs/sherlock/module/web/data/models/db/Template.kt
@@ -32,7 +32,7 @@ open class Template {
     var account: Account? = null
 
     @JvmField
-    @OneToMany(fetch = FetchType.EAGER, mappedBy = "template", cascade = [CascadeType.ALL])
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "template", cascade = [CascadeType.REMOVE])
     var detectors: MutableSet<TDetector> = mutableSetOf()
 
     override operator fun equals(other: Any?): Boolean {

--- a/src/main/resources/application-server.properties
+++ b/src/main/resources/application-server.properties
@@ -2,11 +2,6 @@ spring.application.name=SherlockServer
 logging.level.root=warn
 server.port=8080
 
-spring.datasource.url=jdbc:h2:file:~/sherlock-web
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-
 sherlock.security.key=${SECURITY_KEY}
 
 spring.devtools.add-properties=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,3 +11,9 @@ spring.servlet.multipart.max-file-size=2048MB
 spring.servlet.multipart.max-request-size=2048MB
 
 spring.jpa.open-in-view=false
+
+spring.datasource.jdbc-url=jdbc:h2:file:~/.Sherlock/sherlock-web
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,4 +16,3 @@ spring.datasource.jdbc-url=jdbc:h2:file:~/.Sherlock/sherlock-web
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Description

Since the entire project has been migrated to SpringBoot v3 and Java 21 and Kotlin, the database connection lost its proper status

So in this PR, we refactored the connection of H2 DB, and to let it impact on both `client` and `server` profiles.

Before applying these changes, we found the following problems:
- Go to a template, and make some updates, for example, unselect some of detectors, then save, and go outside then go into this template again, you will see that detector still be selected.
- However, the "Manage Parameters" values can be updated
- The template can not be deleted

For the problem "template & workspace will go after restart", we found that is because the original DB URL is wrong. It should be `jdbc:h2:file:~/.Sherlock/sherlock-web` not `jdbc:h2:file:~/sherlock-web`.

For the problem "template can not be updated", we found that the cascade type `ALL` is the root cause. Setting cascade type to `ALL` can lead to conflicts when trying to select/unselect a `Detector` in a `Template` because `Template`, as a parent entity, 1-to-many `Detectors`, will try to perform all other operations (PERSIST, MERGE, REFRESH, DETACH) before REMOVE (possibly). This can cause problem because there're some FKs (Foreign Keys) constrains between tables.

- resources/db/migration/h2/V1__Initial.sql
```sql
ALTER TABLE PUBLIC.DETECTOR ADD CONSTRAINT DETECTOR_REF_TEMPLATE FOREIGN KEY (TEMPLATE) REFERENCES PUBLIC.TEMPLATE (ID);
```

Similar cases are also exists in other relations. So this PR also simplified their cascade type to only REMOVE.