### PR TITLE
Fix objectdb log file cannot create

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ WORKDIR /app
 # Copy the built jar file from the build stage
 COPY --from=build --chown=appuser:appuser /app/build/out/*.jar ./app.jar
 
+# Copy the objectdb configuration file
+COPY src/main/resources/objectdb.conf /app/objectdb.conf
+
 ENV SECURITY_KEY=sherlock
 ENV ADMIN_PASSWORD=sherlock
+ENV OBJECTDB_CONF=/app/objectdb.conf
 
 CMD ["java", "-jar", "/app/app.jar"]

--- a/src/main/java/uk/ac/warwick/dcs/sherlock/engine/storage/EmbeddedDatabase.java
+++ b/src/main/java/uk/ac/warwick/dcs/sherlock/engine/storage/EmbeddedDatabase.java
@@ -21,6 +21,17 @@ public class EmbeddedDatabase {
         properties.put("javax.persistence.jdbc.user", "admin");
         properties.put("javax.persistence.jdbc.password", "admin");
 
+        // Set the ObjectDB configuration file path
+        // Check for an environment variable that specifies the ObjectDB configuration file path
+        String objectdbConfigPath = System.getenv("OBJECTDB_CONF");
+        if (objectdbConfigPath == null || objectdbConfigPath.isEmpty()) {
+            // Fallback to default configuration file path
+            objectdbConfigPath = "src/main/resources/objectdb.conf";
+        }
+
+        // Set the system property for ObjectDB configuration file
+        System.setProperty("objectdb.conf", objectdbConfigPath);
+
         this.dbFactory = Persistence.createEntityManagerFactory("objectdb:" + SherlockEngine.configuration.getDataPath() + File.separator + "Sherlock.odb", properties);
         this.em = this.dbFactory.createEntityManager();
         this.em.flush();

--- a/src/main/resources/objectdb.conf
+++ b/src/main/resources/objectdb.conf
@@ -1,0 +1,10 @@
+<objectdb>
+<general>
+  <temp path="$temp/ObjectDb" threshold="0mb" />
+  <network inactivity-timeout="0" />
+  <url-history size="0" user="false" password="false" />
+  <log path="" max="0mb" stdout="false" stderr="false" />
+  <log-archive path="$objectdb/log/archive/" retain="0" />
+  <logger name="*" level="fatal" />
+</general>
+</objectdb>


### PR DESCRIPTION
## Description
The objectdb will try to create some log files when it is run in jar mode. Sometimes it is not able to create these log files in specific environment. If that happened, the following error message will present:

```
com.objectdb.o._PersistenceException: Failed to create a new file '/app/nested:/app/app.jar/!BOOT-INF/log/odb20240618.log'
Caused by: com.objectdb.o.UserException: Failed to create a new file '/app/nested:/app/app.jar/!BOOT-INF/log/odb20240618.log'
Caused by: java.io.FileNotFoundException: /app/nested:/app/app.jar/!BOOT-INF/log/odb20240618.log (No such file or directory)
```

So this PR tries to disable the log creation of objectdb, since we actually don't need these log files.